### PR TITLE
Update linear_ring.dart

### DIFF
--- a/lib/src/featureTypes/geometries/linear_ring.dart
+++ b/lib/src/featureTypes/geometries/linear_ring.dart
@@ -196,8 +196,8 @@ class LinearRing {
           // if the point is to the right of the current polygon edge
           c = !c;
         }
-        testCoord = coord;
       }
+    testCoord = coord;
     }
     return c;
   }


### PR DESCRIPTION
Fixed bug where the next point would only be iterated to if a crossing was detected. This was causing an issue where the edges of the linear ring/polygon where not being traversed as expected.